### PR TITLE
Core inheritance from kOSProcessorFields

### DIFF
--- a/src/kOS/Binding/MissionSettings.cs
+++ b/src/kOS/Binding/MissionSettings.cs
@@ -2,6 +2,7 @@ using kOS.Safe.Binding;
 using kOS.Suffixed;
 using kOS.Suffixed.Part;
 using kOS.Utilities;
+using kOS.Module;
 
 namespace kOS.Binding
 {
@@ -10,7 +11,7 @@ namespace kOS.Binding
     {
         public override void AddTo(SharedObjects shared)
         {
-            shared.BindingMgr.AddGetter("CORE", () => new Core(shared));
+            shared.BindingMgr.AddGetter("CORE", () => new Core((kOSProcessor)shared.Processor, shared));
 
             shared.BindingMgr.AddSetter("TARGET", val =>
             {

--- a/src/kOS/Core.cs
+++ b/src/kOS/Core.cs
@@ -1,18 +1,19 @@
 ﻿using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Persistence;
+using kOS.Module;
 using kOS.Suffixed;
 using kOS.Suffixed.Part;
+using kOS.Suffixed.PartModuleField;
 using kOS.Utilities;
 using System;
 using System.Linq;
 
 namespace kOS
 {
-    public class Core : Structure
+    public class Core : kOSProcessorFields
     {
         public static VersionInfo VersionInfo;
-        private readonly SharedObjects shared;
 
         static Core()
         {
@@ -20,20 +21,16 @@ namespace kOS
             VersionInfo = new VersionInfo(ver.Major, ver.Minor, ver.Build);
         }
 
-        public Core(SharedObjects shared)
+        public Core(kOSProcessor processor, SharedObjects shared):base(processor, shared)
         {
-            this.shared = shared;
             InitializeSuffixes();
         }
 
         private void InitializeSuffixes()
         {
             AddSuffix("VERSION", new Suffix<VersionInfo>(() => VersionInfo));
-            AddSuffix("PART", new Suffix<PartValue>(() => new PartValue(shared.KSPPart, shared)));
             AddSuffix("VESSEL", new Suffix<VesselTarget>(() => new VesselTarget(shared.KSPPart.vessel, shared)));
             AddSuffix("ELEMENT", new Suffix<ElementValue>(GetEelement));
-            AddSuffix("VOLUME", new Suffix<Volume>(() => { throw new NotImplementedException(); }));
-            AddSuffix("BOOTFILENAME", new SetSuffix<string>(GetBootFilename, SetBootFilename, "The name of the processor's boot file."));
             AddSuffix("CURRENTVOLUME", new Suffix<Volume>(GetCurrentVolume, "The currently selected volume"));
         }
 
@@ -47,16 +44,6 @@ namespace kOS
         private Volume GetCurrentVolume()
         {
             return shared.VolumeMgr.CurrentVolume;
-        }
-
-        private string GetBootFilename()
-        {
-            return shared.Processor.BootFilename;
-        }
-
-        private void SetBootFilename(string name)
-        {
-            shared.Processor.BootFilename = name;
         }
     }
 }

--- a/src/kOS/Module/kOSProcessor.cs
+++ b/src/kOS/Module/kOSProcessor.cs
@@ -35,7 +35,7 @@ namespace kOS.Module
             get
             {
                 KOSNameTag tag = part.Modules.OfType<KOSNameTag>().FirstOrDefault();
-                return tag != null ? tag.nameTag : null;
+                return tag == null ? string.Empty : tag.nameTag;
             }
         }
 


### PR DESCRIPTION
Core.cs
- Update Core class to inherit from the new kOSProcessorFields class
- Removed duplicate suffixes
- Modify constructor to match that of kOSProcessorFields

MissionSettings.cs
- Update the core binding to use the new constructor

kOSProcessor.cs
- Tag now return an empty string if the name tag is null.
