### PR TITLE
Use fixed time in Cpu execution

### DIFF
--- a/src/kOS/Execution/CPU.cs
+++ b/src/kOS/Execution/CPU.cs
@@ -891,7 +891,7 @@ namespace kOS.Execution
 
             if (showStatistics) updateWatch = Stopwatch.StartNew();
 
-            currentTime = shared.UpdateHandler.CurrentTime;
+            currentTime = shared.UpdateHandler.CurrentFixedTime;
 
             try
             {


### PR DESCRIPTION
CPU.cs
- Use UpdateHandler.CurrentFixedTime in the cpu's fixed update.  This way wait commands will respect time warp conditions.
